### PR TITLE
HOTFIX - Skips setting multipart headers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 20
       - name: NPM Install
         run: npm i
       - name: Build

--- a/src/encode-request-body.test.ts
+++ b/src/encode-request-body.test.ts
@@ -44,7 +44,7 @@ describe('encodeRequestBody', () => {
 
       expect(result).to.have.property('body').equals(body);
       expect(result).to.have.property('headers')
-        .that.include({'Content-Type': 'multipart/form-data'});
+        .that.not.include.keys(['Content-Type']);
     });
   });
 });

--- a/src/encode-request-body.test.ts
+++ b/src/encode-request-body.test.ts
@@ -18,8 +18,7 @@ describe('encodeRequestBody', () => {
       const result = encodeRequestBody(body);
 
       expect(result).to.have.property('body').equals(body);
-      expect(result).to.have.property('headers')
-        .that.include({'Content-Type': 'text/plain'});
+      expect(result).to.not.have.property('headers');
     });
   });
 
@@ -29,9 +28,8 @@ describe('encodeRequestBody', () => {
     it('encodes the body as "application/x-www-form-urlencoded"', () => {
       const result = encodeRequestBody(body);
 
-      expect(result).to.have.property('body').equals(body.toString());
-      expect(result).to.have.property('headers')
-        .that.include({'Content-Type': 'application/x-www-form-urlencoded'});
+      expect(result).to.have.property('body').equals(body);
+      expect(result).to.not.have.property('headers');
     });
   });
 
@@ -43,8 +41,7 @@ describe('encodeRequestBody', () => {
       const result = encodeRequestBody(body);
 
       expect(result).to.have.property('body').equals(body);
-      expect(result).to.have.property('headers')
-        .that.not.include.keys(['Content-Type']);
+      expect(result).to.not.have.property('headers');
     });
   });
 });

--- a/src/encode-request-body.ts
+++ b/src/encode-request-body.ts
@@ -15,7 +15,7 @@ function encodeRequestBodyUrl(body: URLSearchParams): EncondedRequest {
 function encodeRequestBodyMultiPart(body: FormData): EncondedRequest<FormData> {
   return {
     body,
-    headers: {'Content-Type': 'multipart/form-data'},
+    headers: {},
   };
 }
 

--- a/src/encode-request-body.ts
+++ b/src/encode-request-body.ts
@@ -1,32 +1,11 @@
 import { THeaders } from './types';
 
-export interface EncondedRequest<T = string> {
-  headers: THeaders;
-  body: T extends string ? string : FormData;
+export interface EncodedRequest<T extends string | FormData | URLSearchParams> {
+  headers?: THeaders;
+  body: T;
 }
 
-function encodeRequestBodyUrl(body: URLSearchParams): EncondedRequest {
-  return {
-    body: body.toString(),
-    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-  };
-}
-
-function encodeRequestBodyMultiPart(body: FormData): EncondedRequest<FormData> {
-  return {
-    body,
-    headers: {},
-  };
-}
-
-function encodeRequestBodyTextPlain(body: string): EncondedRequest {
-  return {
-    body,
-    headers: {'Content-Type': 'text/plain'},
-  };
-}
-
-function encodeRequestBodyJson(body: unknown): EncondedRequest {
+function encodeRequestBodyJson(body: unknown): EncodedRequest<string> {
   return {
     body: JSON.stringify(body),
     headers: {'Content-Type': 'application/json'},
@@ -35,24 +14,22 @@ function encodeRequestBodyJson(body: unknown): EncondedRequest {
 
 export function encodeRequestBody<T extends URLSearchParams>(
   body: T,
-): EncondedRequest<string>;
+): EncodedRequest<URLSearchParams>;
 export function encodeRequestBody<T extends FormData>(
   body: T,
-): EncondedRequest<FormData>;
+): EncodedRequest<FormData>;
 export function encodeRequestBody<T>(
   body: T,
-): EncondedRequest<string>;
+): EncodedRequest<string>;
 export function encodeRequestBody(
   body: unknown,
-): EncondedRequest<string | FormData> {
-  if (body instanceof URLSearchParams) {
-    return encodeRequestBodyUrl(body);
-  }
-  if (typeof FormData !== 'undefined' && body instanceof FormData) {
-    return encodeRequestBodyMultiPart(body);
-  }
-  if (typeof body === 'string') {
-    return encodeRequestBodyTextPlain(body);
+): EncodedRequest<string | FormData> {
+  if (
+    body instanceof URLSearchParams
+    || (typeof FormData !== 'undefined' && body instanceof FormData)
+    || typeof body === 'string'
+  ) {
+    return {body};
   }
 
   return encodeRequestBodyJson(body);


### PR DESCRIPTION
We should not set the content type of the multipart because it should be set automatically by fetch (browser). Otherwise it overrides it completely and prevents the boundaries to be set which are necessary for this content type